### PR TITLE
Update nyrna.desktop

### DIFF
--- a/packaging/PKGBUILD/nyrna.desktop
+++ b/packaging/PKGBUILD/nyrna.desktop
@@ -7,4 +7,4 @@ Exec=nyrna
 Icon=nyrna
 Terminal=false
 StartupNotify=false
-Categories=Application;
+Categories=Utility;


### PR DESCRIPTION
`Application` is not a correct category. This line should contain one or more of the following categories listed in [specifications](https://specifications.freedesktop.org/menu-spec/latest/apa.html).