### PR TITLE
Fixed CRIU typo and added link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ I haven't seen this issue, however if at any time the hotkey isn't working to re
 
 **Can I suspend to disk so that I can restore after reboot / free up RAM usage / etc?**
 
-Unfortunately no. CRUI looks very promising to allow us to do this (on linux), however it [does not currently support suspending GUI applications](https://criu.org/X_applications).
+Unfortunately no. [CRIU](https://criu.org/) looks very promising to allow us to do this (on linux), however it [does not currently support suspending GUI applications](https://criu.org/X_applications).


### PR DESCRIPTION
I saw a small typo at the end where CRIU was spelled CRUI, so I decided to fix it for you. I also turned it into a link to the CRIU project's website. 