### PR TITLE
Filter dwm.exe on win32

### DIFF
--- a/lib/application/app/cubit/app_cubit.dart
+++ b/lib/application/app/cubit/app_cubit.dart
@@ -205,6 +205,7 @@ List<String> _filteredWindows = [
   'nyrna',
   'nyrna.exe',
   'ApplicationFrameHost.exe', // Manages UWP (Universal Windows Platform) apps
+  'dwm.exe', // Win32's compositing window manager
   'explorer.exe', // Windows File Explorer
   'googledrivesync.exe',
   'LogiOverlay.exe', // Logitech Options


### PR DESCRIPTION
The system can occasionally report seeing windows with an
executable of `dwm.exe`, which is actually the win32 compositing
window manager - not an application window at all.

This change filters out any supposed "window" associated with dwm.exe

Resolves #57