### PR TITLE
Remember own window size for next launch

### DIFF
--- a/lib/application/helpers/json_converters.dart
+++ b/lib/application/helpers/json_converters.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: unnecessary_this
+
+import 'dart:convert';
+import 'dart:ui';
+
+/// Converts Rect objects to / from json easily.
+///
+/// Needed so they can be saved as a String to preferences.
+extension RectConverter on Rect {
+  static Rect fromJson(String json) {
+    final rectMap = jsonDecode(json) as Map<String, dynamic>;
+    return Rect.fromLTWH(
+      rectMap['left'],
+      rectMap['top'],
+      rectMap['width'],
+      rectMap['height'],
+    );
+  }
+
+  String toJson() {
+    final rectMap = <String, dynamic>{
+      'left': this.left,
+      'top': this.top,
+      'width': this.width,
+      'height': this.height,
+    };
+    return jsonEncode(rectMap);
+  }
+}

--- a/lib/application/preferences/cubit/preferences_cubit.dart
+++ b/lib/application/preferences/cubit/preferences_cubit.dart
@@ -9,6 +9,9 @@ import 'package:nyrna/infrastructure/icon_manager/icon_manager.dart';
 import 'package:nyrna/infrastructure/launcher/launcher.dart';
 import 'package:nyrna/infrastructure/preferences/preferences.dart';
 import 'package:nyrna/presentation/styles.dart';
+import 'package:window_size/window_size.dart' as window;
+
+import '../../helpers/json_converters.dart';
 
 part 'preferences_state.dart';
 
@@ -89,5 +92,20 @@ class PreferencesCubit extends Cubit<PreferencesState> {
   Future<void> updateShowHiddenWindows(bool value) async {
     await _prefs.setBool(key: 'showHiddenWindows', value: value);
     emit(state.copyWith(showHiddenWindows: value));
+  }
+
+  /// Save the current window size & position to storage.
+  Future<void> saveWindowSize() async {
+    final windowInfo = await window.getWindowInfo();
+    final rectJson = windowInfo.frame.toJson();
+    await _prefs.setString(key: 'windowSize', value: rectJson);
+  }
+
+  /// Returns if available the last window size and position.
+  Future<Rect?> savedWindowSize() async {
+    final rectJson = _prefs.getString('windowSize');
+    if (rectJson == null) return null;
+    final windowRect = RectConverter.fromJson(rectJson);
+    return windowRect;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -35,13 +35,13 @@ Future<void> main(List<String> args) async {
 
   final nativePlatform = NativePlatform();
 
+  // Created outside runApp so it can be accessed for window settings below.
+  final prefsCubit = PreferencesCubit(prefs);
+
   runApp(
     MultiBlocProvider(
       providers: [
-        BlocProvider(
-          create: (context) => PreferencesCubit(prefs),
-          lazy: false,
-        ),
+        BlocProvider.value(value: prefsCubit),
         BlocProvider(
           create: (context) => ThemeCubit(prefs),
         ),
@@ -63,5 +63,9 @@ Future<void> main(List<String> args) async {
     ),
   );
 
+  final savedWindowSize = await preferencesCubit.savedWindowSize();
+  if (savedWindowSize != null) {
+    window.setWindowFrame(savedWindowSize);
+  }
   window.setWindowVisibility(visible: true);
 }

--- a/lib/presentation/app/pages/apps_page.dart
+++ b/lib/presentation/app/pages/apps_page.dart
@@ -9,8 +9,40 @@ import '../app.dart';
 /// The main screen for Nyrna.
 ///
 /// Shows a ListView with tiles for each open window on the current desktop.
-class AppsPage extends StatelessWidget {
+class AppsPage extends StatefulWidget {
   static const id = 'running_apps_screen';
+
+  @override
+  State<AppsPage> createState() => _AppsPageState();
+}
+
+class _AppsPageState extends State<AppsPage> with WidgetsBindingObserver {
+  /// Tracks the current window size.
+  late Size _appWindowSize;
+
+  @override
+  void initState() {
+    super.initState();
+    _appWindowSize = WidgetsBinding.instance!.window.physicalSize;
+    // Listen for changes to the application's window size.
+    WidgetsBinding.instance!.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance!.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    final updatedWindowSize = WidgetsBinding.instance!.window.physicalSize;
+    if (_appWindowSize != updatedWindowSize) {
+      _appWindowSize = updatedWindowSize;
+      preferencesCubit.saveWindowSize();
+    }
+    super.didChangeMetrics();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Whenever the window is resized the new size will be saved to
local storage via shared_preferences so it can be set to that
size again on the next application startup.