### PR TITLE
Refresh process status for all windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           flutter pub get
 
+      - name: Run unit tests
+        run: |
+          flutter test
+
       - name: Test native_platform
         run: |
           cd packages/native_platform

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,14 +49,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.0.1"
-  bloc_test:
-    dependency: "direct main"
-    description:
-      name: bloc_test
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "9.0.1"
+    version: "8.0.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -120,13 +113,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  diff_match_patch:
-    dependency: transitive
-    description:
-      name: diff_match_patch
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.1"
   equatable:
     dependency: "direct main"
     description:
@@ -298,7 +284,7 @@ packages:
     source: hosted
     version: "1.0.0"
   mocktail:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: mocktail
       url: "https://pub.dartlang.org"
@@ -576,7 +562,7 @@ packages:
     source: hosted
     version: "1.2.0"
   test:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   active_window:
     path: packages/active_window
   args: ^2.2.0
-  bloc_test: ^9.0.1
   equatable: ^2.0.3
   flex_color_picker: ^2.0.1
   flutter:
@@ -39,7 +38,9 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+  mocktail: ^0.2.0
   pedantic: ^1.11.0
+  test: ^1.19.5
 
 flutter:
   uses-material-design: true

--- a/test/application/app/cubit/app_cubit_test.dart
+++ b/test/application/app/cubit/app_cubit_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'package:native_platform/native_platform.dart';
+import 'package:nyrna/application/app/app.dart';
+import 'package:nyrna/application/preferences/cubit/preferences_cubit.dart';
+import 'package:nyrna/infrastructure/preferences/preferences.dart';
+import 'package:nyrna/infrastructure/versions/versions.dart';
+
+class MockPreferences extends Mock implements Preferences {}
+
+class MockPreferencesCubit extends Mock implements PreferencesCubit {
+  MockPreferencesCubit()
+      : _state = PreferencesState(
+          autoRefresh: false,
+          autoStartHotkey: false,
+          refreshInterval: 5,
+          showHiddenWindows: false,
+          trayIconColor: Colors.amber,
+        );
+
+  final PreferencesState _state;
+
+  @override
+  PreferencesState get state => _state;
+}
+
+class MockPrefsCubitState extends Mock implements PreferencesState {}
+
+class MockNativePlatform extends Mock implements NativePlatform {
+  @override
+  Future<int> currentDesktop() async => 0;
+}
+
+class MockVersions implements Versions {
+  @override
+  Future<String> latestVersion() async => '2.3.0';
+
+  @override
+  Future<String> runningVersion() async => '2.3.0';
+
+  @override
+  Future<bool> updateAvailable() async => false;
+}
+
+final msPaintWindow = Window(
+  id: 132334,
+  process: Process(
+    executable: 'mspaint.exe',
+    pid: 3716,
+    status: ProcessStatus.normal,
+  ),
+  title: 'Untitled - Paint',
+);
+
+void main() {
+  group('AppCubit', () {
+    final _nativePlatform = MockNativePlatform();
+    final _prefs = MockPreferences();
+    final _prefsCubit = MockPreferencesCubit();
+    final _versions = MockVersions();
+
+    late AppCubit _appCubit;
+
+    setUp(() {
+      _appCubit = AppCubit(
+        nativePlatform: _nativePlatform,
+        prefs: _prefs,
+        prefsCubit: _prefsCubit,
+        versionRepository: _versions,
+        testing: true,
+      );
+
+      // Start with empty window list.
+      when(() => _nativePlatform.windows(showHidden: false))
+          .thenAnswer((_) async => []);
+    });
+
+    test('Initial state has no windows', () {
+      expect(_appCubit.state.windows.length, 0);
+    });
+
+    test('New window is added to state', () async {
+      final numStartingWindows = _appCubit.state.windows.length;
+
+      when(() => _nativePlatform.windows(showHidden: false)).thenAnswer(
+        (_) async => [
+          msPaintWindow,
+        ],
+      );
+
+      await _appCubit.manualRefresh();
+      final numUpdatedWindows = _appCubit.state.windows.length;
+      expect(numUpdatedWindows, numStartingWindows + 1);
+    });
+
+    test('ProcessStatus changing externally updates state', () async {
+      when(() => _nativePlatform.windows(showHidden: false)).thenAnswer(
+        (_) async => [msPaintWindow],
+      );
+
+      await _appCubit.manualRefresh();
+
+      // Verify we have one window, and it has a normal status.
+      var windows = _appCubit.state.windows;
+      expect(windows.length, 1);
+      var window = windows[0];
+      expect(window.process.status, ProcessStatus.normal);
+
+      // Simulate the process being suspended outside Nyrna.
+      when(() => _nativePlatform.windows(showHidden: false)).thenAnswer(
+        (_) async => [
+          msPaintWindow.copyWith(
+            process: msPaintWindow.process.copyWith(
+              status: ProcessStatus.suspended,
+            ),
+          ),
+        ],
+      );
+
+      // Verify we pick up this status change.
+      await _appCubit.manualRefresh();
+      windows = _appCubit.state.windows;
+      expect(windows.length, 1);
+      window = windows[0];
+      expect(window.process.status, ProcessStatus.suspended);
+    });
+  });
+}


### PR DESCRIPTION
The current implementation was probably an attempt to reduce
resource usage for Windows, however it was poorly done and was
causing existing windows to not update their status unless that
tile specifically was clicked.

Fixes #51