### PR TITLE
WindowTile: check if widget is mounted after async call

### DIFF
--- a/lib/apps_list/widgets/window_tile.dart
+++ b/lib/apps_list/widgets/window_tile.dart
@@ -64,6 +64,8 @@ class _WindowTileState extends State<WindowTile> {
             onTap: () async {
               setState(() => loading = true);
               await context.read<AppsListCubit>().toggle(window);
+
+              if (!mounted) return;
               setState(() => loading = false);
             },
           ),


### PR DESCRIPTION
If the widget is no longer mounted things like setState can
cause a crash

Related to #108