### PR TITLE
chore(flatpak): cut description to minimum

### DIFF
--- a/packaging/linux/codes.merritt.Nyrna.metainfo.xml
+++ b/packaging/linux/codes.merritt.Nyrna.metainfo.xml
@@ -26,25 +26,13 @@ https://www.freedesktop.org/software/appstream/metainfocreator/#/
   </keywords>
   <description>
     <p>Similar to the incredibly useful sleep/suspend function found in consoles like the Nintendo Switch and Sony PlayStation; suspend your game (and its resource usage) at any time, and resume whenever you wish - at the push of a button.</p>
-    <p>
-      <em>Suspend Games</em>
-    </p>
     <ul>
       <li>Pause cutscenes to read the subtitles, examine the scene, answer the door, etc.</li>
       <li>Pause games that can't normally be paused (single-player games like Dark Souls, Elden Ring, etc)</li>
       <li>Suspend games whose pause screens keep the system running hot or playing unwanted music</li>
       <li>Suspend inbetween checkpoints (example: Hollow Knight)</li>
     </ul>
-    <p>
-      <em>Suspend Applications</em>
-    </p>
-    <p>Nyrna can be used to suspend normal, non-game applications as well. For example:</p>
-    <ul>
-      <li>3D renders</li>
-      <li>video encoding</li>
-      <li>software compilation</li>
-    </ul>
-    <p>The CPU and GPU resources are being used by said task - maybe for hours - when you would like to use the system for something else. With Nyrna you can suspend that program, freeing up the resources (excluding RAM) until the process is resumed, without losing where you were - like the middle of a long job, or a gaming session between save points.</p>
+    <p>Nyrna can be used to suspend normal, non-game applications as well.</p>
   </description>
   <launchable type="desktop-id">codes.merritt.Nyrna.desktop</launchable>
   <screenshots>


### PR DESCRIPTION
Flathub apparently requires very, very brief descriptions:

> • style-invalid : Too many <p> tags for a good description [35/15]

¯\_(ツ)_/¯