### PR TITLE
fix: explicitly set `en` as the fallback language

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,3 +1,4 @@
 arb-dir: lib/localization
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+preferred-supported-locales: [en]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: nyrna
 description: Suspend any game or application.
 publish_to: "none"
-version: 2.16.0
+version: 2.16.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Without this it defaults to the first supported language
in the list alphabetically.

See:
https://github.com/flutter/flutter/issues/100857#issuecomment-1559653376

Fixes #181