### PR TITLE
fix: display emojis in color

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -3,11 +3,20 @@ import 'package:flutter/material.dart';
 /// Nyrna's branded color.
 const nyrnaColor = Color.fromRGBO(0, 179, 255, 1);
 
+const _kFallbackFontFamilies = [
+  /// Fallback to Noto Color Emoji is needed to render emojis in color.
+  ///
+  /// See:
+  /// https://github.com/flutter/flutter/issues/119536
+  'Noto Color Emoji',
+];
+
 /// Dark app theme.
 final ThemeData darkTheme = ThemeData(
   useMaterial3: true,
   brightness: Brightness.dark,
   colorSchemeSeed: nyrnaColor,
+  fontFamilyFallback: _kFallbackFontFamilies,
 );
 
 /// Light app theme.
@@ -15,6 +24,7 @@ final ThemeData lightTheme = ThemeData(
   useMaterial3: true,
   brightness: Brightness.light,
   colorSchemeSeed: nyrnaColor,
+  fontFamilyFallback: _kFallbackFontFamilies,
 );
 
 /// Perfectly black theme for use on AMOLED screens.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -380,8 +380,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "3b8b7acebb96f43932579f15dcf136e282f6602c"
-      resolved-ref: "3b8b7acebb96f43932579f15dcf136e282f6602c"
+      ref: "25abb2f2d4758ffbf1cc166adc3047df5117aa4d"
+      resolved-ref: "25abb2f2d4758ffbf1cc166adc3047df5117aa4d"
       url: "https://github.com/Merrit/helpers.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   helpers:
     git:
       url: https://github.com/Merrit/helpers.git
-      ref: 3b8b7acebb96f43932579f15dcf136e282f6602c
+      ref: 25abb2f2d4758ffbf1cc166adc3047df5117aa4d
   hive_flutter: ^1.1.0
 
   # Using a fork of hotkey_manager to fix a bug.


### PR DESCRIPTION
Fallback to Noto Color Emoji is needed to render emojis in color.

See:
https://github.com/flutter/flutter/issues/119536