### PR TITLE
fix: remove emoji fallback font

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -3,20 +3,11 @@ import 'package:flutter/material.dart';
 /// Nyrna's branded color.
 const nyrnaColor = Color.fromRGBO(0, 179, 255, 1);
 
-const _kFallbackFontFamilies = [
-  /// Fallback to Noto Color Emoji is needed to render emojis in color.
-  ///
-  /// See:
-  /// https://github.com/flutter/flutter/issues/119536
-  'Noto Color Emoji',
-];
-
 /// Dark app theme.
 final ThemeData darkTheme = ThemeData(
   useMaterial3: true,
   brightness: Brightness.dark,
   colorSchemeSeed: nyrnaColor,
-  fontFamilyFallback: _kFallbackFontFamilies,
 );
 
 /// Light app theme.
@@ -24,7 +15,6 @@ final ThemeData lightTheme = ThemeData(
   useMaterial3: true,
   brightness: Brightness.light,
   colorSchemeSeed: nyrnaColor,
-  fontFamilyFallback: _kFallbackFontFamilies,
 );
 
 /// Perfectly black theme for use on AMOLED screens.


### PR DESCRIPTION
With new Flutter version it was causing all text
to be rendered with the emoji font, which looks
terrible.