### PR TITLE
fix: pin Windows version to working version

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -23,16 +23,17 @@ jobs:
     with:
       pre-release: true
     secrets: inherit
-  call-build-windows:
-    needs: call-tests
-    uses: ./.github/workflows/build-windows.yml
-    with:
-      pre-release: true
-    secrets: inherit
+  # call-build-windows:
+  #   needs: call-tests
+  #   uses: ./.github/workflows/build-windows.yml
+  #   with:
+  #     pre-release: true
+  #   secrets: inherit
 
   pre-release:
     name: "Pre Release"
-    needs: [call-build-linux, call-build-windows]
+    # needs: [call-build-linux, call-build-windows]
+    needs: [call-build-linux]
     runs-on: "ubuntu-latest"
 
     steps:
@@ -52,4 +53,4 @@ jobs:
           title: "Development Build"
           files: |
             ${{ github.workspace }}/artifacts/linux-artifacts/*
-            ${{ github.workspace }}/artifacts/windows-artifacts/*
+          # ${{ github.workspace }}/artifacts/windows-artifacts/*

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,16 +21,17 @@ jobs:
     with:
       pre-release: true
     secrets: inherit
-  call-build-windows:
-    needs: call-tests
-    uses: ./.github/workflows/build-windows.yml
-    with:
-      pre-release: true
-    secrets: inherit
+  # call-build-windows:
+  #   needs: call-tests
+  #   uses: ./.github/workflows/build-windows.yml
+  #   with:
+  #     pre-release: true
+  #   secrets: inherit
 
   verify-pull-request:
     name: Verify Pull Request
-    needs: [call-tests, call-build-linux, call-build-windows]
+    # needs: [call-tests, call-build-linux, call-build-windows]
+    needs: [call-tests, call-build-linux]
     runs-on: ubuntu-latest
     steps:
       - run: echo "Requirements passed, PR looks good!"

--- a/.github/workflows/release-windows-store.yml
+++ b/.github/workflows/release-windows-store.yml
@@ -4,9 +4,9 @@ on:
   # Enable manual run
   workflow_dispatch:
   # Build & deploy for published releases
-  release:
-    types:
-      - published
+  # release:
+  #   types:
+  #     - published
 
 concurrency:
     group: ci-release-${{ github.ref }}-1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,17 @@ jobs:
     with:
       pre-release: false
     secrets: inherit
-  call-build-windows:
-    needs: call-tests
-    uses: ./.github/workflows/build-windows.yml
-    with:
-      pre-release: false
-    secrets: inherit
+  # call-build-windows:
+  #   needs: call-tests
+  #   uses: ./.github/workflows/build-windows.yml
+  #   with:
+  #     pre-release: false
+  #   secrets: inherit
 
   release:
     name: "Release"
-    needs: [call-build-linux, call-build-windows]
+    # needs: [call-build-linux, call-build-windows]
+    needs: [call-build-linux]
     runs-on: "ubuntu-latest"
 
     steps:
@@ -50,4 +51,4 @@ jobs:
           prerelease: false
           files: |
             ${{ github.workspace }}/artifacts/linux-artifacts/*
-            ${{ github.workspace }}/artifacts/windows-artifacts/*
+# ${{ github.workspace }}/artifacts/windows-artifacts/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ Unfortunately no. [CRIU](https://criu.org/) looks very promising to allow us to 
 
 ## Troubleshooting
 
-If you use Microsoft Windows, issues are often resolved by running Nyrna as an administrator.
+The Windows version is unlikely to receive further updates, and is not as stable
+as the Linux version.
+
+If you use Microsoft Windows, issues are often resolved by running Nyrna as an
+administrator.
 
 
 ## Building

--- a/lib/app/cubit/app_cubit.dart
+++ b/lib/app/cubit/app_cubit.dart
@@ -122,6 +122,10 @@ Otherwise, [consider signing in using X11 instead](https://docs.fedoraproject.or
 
   /// Fetches version data from the update service.
   Future<void> _fetchVersionData() async {
+    // Windows version is not being supported for future updates, so we skip fetching
+    // version data for Windows so they don't get an "update available" message.
+    if (Platform.isWindows) return;
+
     final versionInfo = await _updateService.getVersionInfo();
     emit(
       state.copyWith(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: nyrna
 description: Suspend any game or application.
 publish_to: "none"
-version: 2.26.0
+version: 2.26.1
 
 environment:
   sdk: ">=3.8.0 <4.0.0"


### PR DESCRIPTION
After upgrading dependencies, the Windows version of Nyrna stopped working. This change disables the automatic building and release of new Windows versions until the issue can be resolved.

Builds from before the upgrades with the new version number will be attached manually to the release, but no new Windows versions will be built until the issue is resolved.

Resolves #254